### PR TITLE
add --tag parameter to command line options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,12 +47,6 @@ struct Cli {
         requires = "latitude"
     )]
     longitude: Option<String>,
-
-    #[structopt(
-        long = "tag",
-        help = "Add a short description to help identify the process e.g. when using htop. This parameter has no other effect on the running of the program."
-    )]
-    tag: Option<String>,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -86,6 +80,12 @@ pub enum Subcommand {
             required_ifs = &[("event-name", "custom_am"), ("event-name", "custom_pm")],
         )]
         custom_altitude: Option<String>, // we'll validate it to a float later
+
+        #[structopt(
+            long = "tag",
+            help = "Add a short description to help identify the process e.g. when using htop. This parameter has no other effect on the running of the program."
+        )]
+        tag: Option<String>,
     },
 }
 
@@ -171,6 +171,7 @@ impl Config {
                 offset,
                 custom_altitude,
                 event_name,
+                ..
             } => {
                 // do some gymnastics here. Structopt already validates that altitude is provided
                 let altitude = custom_altitude

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,12 @@ struct Cli {
         requires = "latitude"
     )]
     longitude: Option<String>,
+
+    #[structopt(
+        long = "tag",
+        help = "Add a short description to help identify the process e.g. when using htop. This parameter has no other effect on the running of the program."
+    )]
+    tag: Option<String>,
 }
 
 #[derive(Debug, StructOpt, Clone)]

--- a/tests/test_wait.rs
+++ b/tests/test_wait.rs
@@ -332,3 +332,28 @@ fn test_offset_parse_error() {
     .failure()
     .stderr(predicates::str::contains("in the format HH:MM:SS or HH:MM"));
 }
+
+#[test]
+fn test_tag_is_allowed() {
+    let mut cmd = Command::cargo_bin("heliocron").unwrap();
+    let wait_short = cmd
+        .args(&[
+            "--tag",
+            "description of this process",
+            "-d",
+            "2091-10-05",
+            "-t",
+            "+00:00",
+            "wait",
+            "-e",
+            "sunrise",
+            "-o",
+            "-12:30:52",
+        ])
+        .assert();
+
+    wait_short
+        .success()
+        .stdout(predicates::str::contains("going to sleep for"))
+        .stdout(predicates::str::contains("2091-10-04 17:37:02 +00:00"));
+}

--- a/tests/test_wait.rs
+++ b/tests/test_wait.rs
@@ -338,8 +338,6 @@ fn test_tag_is_allowed() {
     let mut cmd = Command::cargo_bin("heliocron").unwrap();
     let wait_short = cmd
         .args(&[
-            "--tag",
-            "description of this process",
             "-d",
             "2091-10-05",
             "-t",
@@ -349,6 +347,8 @@ fn test_tag_is_allowed() {
             "sunrise",
             "-o",
             "-12:30:52",
+            "--tag",
+            "description of this process",
         ])
         .assert();
 


### PR DESCRIPTION
closes #24 

now you can do something like:

`heliocron wait --event sunset --tag "brief description of this process"`

And then, when interrogating your processes with `htop`, for example, the --tag parameter will show up (so you can filter using it, or it can describe what the purpose of this particular wait command is for).

