### PR TITLE
add solar_noon to --event options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.6.0] - 2022-XX-XX
 ### Added
 - `SleepError` variant for `RuntimeErrorKind`. Contributed by [@4e554c4c](https://github.com/4e554c4c) as part of [#45](https://github.com/mfreeborn/heliocron/pull/45).
+
 ### Changed
 - Switched underlying implementation in the library from `sync` to `async`. Resolves [#43](https://github.com/mfreeborn/heliocron/issues/43). This adds dependencies to `tokio` and [tokio-walltime](https://crates.io/crates/tokio-walltime). Contibuted by [@4e554c4c](https://github.com/4e554c4c).
 - The `wait` library function input arguments changed from a `Duration` to a `DateTime<FixedOffset>`.
 - Internal improvements to error handling.
 - Refactor tests to avoid running real `wait` command.
+
+### Fixed
+- Updated missing details in README.
+
 
 ## [Pre v0.5.0]
 - Changelog not started

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ heliocron [Options] <Subcommand> [Subcommand Options]
     | `astronomical_dusk` | The moment when the geometric centre of the Sun reaches 18° below the horizon as it is setting |
     | `custom_am` | Allows the user to specify the moment when the geometric centre of the Sun reaches a custom number of degrees below the horizon as it is rising |
     | `custom_pm` | Allows the user to specify the moment when the geometric centre of the Sun reaches a custom number of degrees below the horizon as it is setting |
+    | `solar_noon` | The moment when the Sun reaches its highest point in the sky |
 
   * `-a, --altitude` [required if `--event` is one of { `custom_am` | `custom_pm` }]
 


### PR DESCRIPTION
Closes #40 

Looks like `solar_noon` was already supported as an `--event` command line option, but it wasn't documented in the readme.