### PR TITLE
Add flag and default behaviour for missed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.6.0] - 2022-XX-XX
 ### Added
+- Add `--run-missed-task` flag to `wait` subcommand ([#48](https://github.com/mfreeborn/heliocron/pull/48)).
 - `SleepError` variant for `RuntimeErrorKind`. Contributed by [@4e554c4c](https://github.com/4e554c4c) as part of [#45](https://github.com/mfreeborn/heliocron/pull/45).
 
 ### Changed
@@ -16,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Updated missing details in README.
-
 
 ## [Pre v0.5.0]
 - Changelog not started

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Heliocron
+# heliocron
 
 [![crates.io](https://img.shields.io/crates/v/heliocron.svg)](https://crates.io/crates/heliocron)
 [![crates.io](https://img.shields.io/crates/d/heliocron.svg)](https://crates.io/crates/heliocron)
 [![Build Status](https://github.com/mfreeborn/heliocron/workflows/ci/badge.svg)](https://github.com/mfreeborn/heliocron/actions)
 
-A command line application that integrates with cron to execute tasks relative to sunset, sunrise and other such solar events.
+A simple command line application that integrates with `cron` to execute tasks relative to sunset, sunrise and other such solar events.
 
 ## Table of Contents
 
@@ -16,11 +16,11 @@ A command line application that integrates with cron to execute tasks relative t
 
 ## Installation
 
-There are several ways to install heliocron on your device.
+There are several ways to install `heliocron` on your device.
 
 ### 1. Pre-compiled binaries
 
-Simply download a pre-compiled binary from the [releases](https://github.com/mfreeborn/heliocron/releases) page.
+You can download a pre-compiled binary from the [releases](https://github.com/mfreeborn/heliocron/releases) page.
 
 Here's a quick compatibility table to help choose the correct binary to download:
 
@@ -68,7 +68,7 @@ wait --event sunset && ls ~
 Thread going to sleep for _ seconds until 2020-02-25 17:32:17 +00:00. Press ctrl+C to cancel.
 ```
 
-Integration with Cron for recurring tasks is easy. The following snippet shows a Crontab entry which will run every morning at 2am. Heliocron will wait until 30 minutes before sunrise, before allowing the execution of the ``turn-on-lights.sh`` script.
+Integration with `cron` for recurring tasks is easy. The following snippet shows a `crontab` entry which will run every morning at 2am. `heliocron` will wait until 30 minutes before sunrise, before allowing the execution of the ``turn-on-lights.sh`` script.
 
 ```bash
 0 2 * * * heliocron --latitude 51.4769N --longitude 0.0005W wait --event sunrise --offset -00:30 \
@@ -108,7 +108,7 @@ Astronomical dusk is at:  Never
 
 ## Configuration
 
-Heliocron supports reading some configuration options from a file located at ~/.config/heliocron.toml. Note that this file is not created by default, it is up to the user to create the file correctly, otherwise Heliocron will simply pass over it. In particular, you can set a default latitude and longitude (must provide both, otherwise it will fall back to the default location of the Royal Greenwich Observatory).
+`heliocron` supports reading some configuration options from a file located at ~/.config/heliocron.toml. Note that this file is not created by default, it is up to the user to create the file correctly, otherwise `heliocron` will simply pass over it. In particular, you can set a default latitude and longitude (must provide both, otherwise it will fall back to the default location of the Royal Greenwich Observatory).
 
 ```toml
 # ~/.config/heliocron.toml
@@ -117,7 +117,7 @@ latitude = "51.5014N"
 longitude = "0.1419W"
 ```
 
-Now, using Heliocron without providing specific coordinates will yield the following output:
+Now, using `heliocron` without providing specific coordinates will yield the following output:
 
 ```bash
 $ heliocron -d 2020-03-08 report
@@ -226,7 +226,7 @@ heliocron [Options] <Subcommand> [Subcommand Options]
 
 * `-f, --format` [default: %Y-%m-%d]
 
-  Specifiy the format of the date string passed to `--date`, using the syntax described [here](https://docs.rs/chrono/0.4.12/chrono/format/strftime/index.html) by the `chrono` crate.
+  Specify the format of the date string passed to `--date`, using the syntax described [here](https://docs.rs/chrono/0.4.12/chrono/format/strftime/index.html) by the `chrono` crate.
 
 * `-l, --latitude` [default: 51.4769N]
 
@@ -271,7 +271,7 @@ heliocron [Options] <Subcommand> [Subcommand Options]
     | `civil_dawn` | The moment when the geometric centre of the Sun reaches 6° below the horizon as it is rising |
     | `civil_dusk` | The moment when the geometric centre of the Sun reaches 6° below the horizon as it is setting |
     | `nautical_dawn` | The moment when the geometric centre of the Sun reaches 12° below the horizon as it is rising |
-    | `nautical_dusk` | The moment when the geometric centre of the Sun reaches 12° below the horizon as it is settting |
+    | `nautical_dusk` | The moment when the geometric centre of the Sun reaches 12° below the horizon as it is setting |
     | `astronomical_dawn` | The moment when the geometric centre of the Sun reaches 18° below the horizon as it is rising |
     | `astronomical_dusk` | The moment when the geometric centre of the Sun reaches 18° below the horizon as it is setting |
     | `custom_am` | Allows the user to specify the moment when the geometric centre of the Sun reaches a custom number of degrees below the horizon as it is rising |
@@ -294,6 +294,10 @@ heliocron [Options] <Subcommand> [Subcommand Options]
   * `-o, --offset` [default: 00:00:00]
 
     Specify an offset, either in [-]HH:MM or [-]HH:MM:SS format, from the chosen event. Negative offsets (those which are prefixed with a '`-`' e.g. `-01:00`) will set the delay to be before the event, whilst positive offsets will shift the delay after the event.
+
+  * `--run-missed-task`
+
+    If this flag is present, then the process will exit successfully even if the event was missed. This can happen, for example, if the device running `heliocron` goes to sleep and does not wake up until after the event has occurred. Without this flag, if the event is missed by more than 30 seconds, then the task will not be run. 
 
   * `--tag` [optional]
     

--- a/src/bin/heliocron.rs
+++ b/src/bin/heliocron.rs
@@ -11,9 +11,9 @@ async fn run_heliocron() -> Result<(), errors::HeliocronError> {
         config::Action::Wait {
             event,
             offset,
-            run_missed_event,
+            run_missed_task,
         } => {
-            subcommands::wait(event, offset, solar_calculations, run_missed_event).await?;
+            subcommands::wait(event, offset, solar_calculations, run_missed_task).await?;
         }
     }
     Ok(())

--- a/src/bin/heliocron.rs
+++ b/src/bin/heliocron.rs
@@ -8,8 +8,12 @@ async fn run_heliocron() -> Result<(), errors::HeliocronError> {
     let solar_calculations = calc::SolarCalculations::new(config.date, config.coordinates);
     match config.action {
         config::Action::Report => subcommands::display_report(solar_calculations)?,
-        config::Action::Wait { event, offset } => {
-            subcommands::wait(event, offset, solar_calculations).await?;
+        config::Action::Wait {
+            event,
+            offset,
+            run_missed_event,
+        } => {
+            subcommands::wait(event, offset, solar_calculations, run_missed_event).await?;
         }
     }
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,6 +86,12 @@ pub enum Subcommand {
             help = "Add a short description to help identify the process e.g. when using htop. This parameter has no other effect on the running of the program."
         )]
         tag: Option<String>,
+
+        #[structopt(
+            help = "Define whether the task should still be run even if the event has been missed. A tolerance of 30 seconds after the event is allowed before a task would be skipped. Setting this flag will cause the task to run regardless of how overdue it is.",
+            long = "run-missed-event"
+        )]
+        run_missed_event: bool,
     },
 }
 
@@ -129,6 +135,7 @@ pub enum Action {
     Wait {
         event: enums::Event,
         offset: Duration,
+        run_missed_event: bool,
     },
 }
 
@@ -171,6 +178,7 @@ impl Config {
                 offset,
                 custom_altitude,
                 event_name,
+                run_missed_event,
                 ..
             } => {
                 // do some gymnastics here. Structopt already validates that altitude is provided
@@ -179,6 +187,7 @@ impl Config {
                 Action::Wait {
                     offset: offset?,
                     event,
+                    run_missed_event,
                 }
             }
             Subcommand::Report {} => Action::Report,

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ pub enum Subcommand {
             help = "Define whether the task should still be run even if the event has been missed. A tolerance of 30 seconds after the event is allowed before a task would be skipped. Setting this flag will cause the task to run regardless of how overdue it is.",
             long = "run-missed-event"
         )]
-        run_missed_event: bool,
+        run_missed_task: bool,
     },
 }
 
@@ -135,7 +135,7 @@ pub enum Action {
     Wait {
         event: enums::Event,
         offset: Duration,
-        run_missed_event: bool,
+        run_missed_task: bool,
     },
 }
 
@@ -178,7 +178,7 @@ impl Config {
                 offset,
                 custom_altitude,
                 event_name,
-                run_missed_event,
+                run_missed_task,
                 ..
             } => {
                 // do some gymnastics here. Structopt already validates that altitude is provided
@@ -187,7 +187,7 @@ impl Config {
                 Action::Wait {
                     offset: offset?,
                     event,
-                    run_missed_event,
+                    run_missed_task,
                 }
             }
             Subcommand::Report {} => Action::Report,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,13 +44,14 @@ impl ConfigErrorKind {
 pub enum RuntimeErrorKind {
     NonOccurringEvent,
     PastEvent,
+    EventMissed(i64),
     SleepError(tokio_walltime::Error),
 }
 
 impl std::fmt::Display for HeliocronError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            HeliocronError::Config(ref err) => write!(
+            Self::Config(ref err) => write!(
                 f,
                 "Config error: {}",
                 match err {
@@ -63,7 +64,7 @@ impl std::fmt::Display for HeliocronError {
                     ConfigErrorKind::InvalidEvent => err.as_str().to_string(),
                 }
             ),
-            HeliocronError::Runtime(ref err) => write!(
+            Self::Runtime(ref err) => write!(
                 f,
                 "Runtime error: {}",
                 match err {
@@ -72,6 +73,7 @@ impl std::fmt::Display for HeliocronError {
                     RuntimeErrorKind::PastEvent => {
                         "The chosen event occurred in the past; cannot wait a negative amount of time.".to_string()
                     }
+                    RuntimeErrorKind::EventMissed(by) => format!("Event missed by {by}s"),
                     RuntimeErrorKind::SleepError(e) => e.to_string(),
                 }
             ),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,7 +73,7 @@ impl std::fmt::Display for HeliocronError {
                     RuntimeErrorKind::PastEvent => {
                         "The chosen event occurred in the past; cannot wait a negative amount of time.".to_string()
                     }
-                    RuntimeErrorKind::EventMissed(by) => format!("Event missed by {by}s"),
+                    RuntimeErrorKind::EventMissed(by) => format!("Event missed by {}s", by),
                     RuntimeErrorKind::SleepError(e) => e.to_string(),
                 }
             ),

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -16,7 +16,7 @@ pub async fn wait(
     event: enums::Event,
     offset: Duration,
     solar_calculations: calc::SolarCalculations,
-    run_missed_event: bool,
+    run_missed_task: bool,
 ) -> Result<()> {
     let event_time = match event {
         enums::Event::SolarNoon => solar_calculations.get_solar_noon(),
@@ -34,7 +34,7 @@ pub async fn wait(
             // catch any scheduling delays that could cause a second or two's delay. At some point, this arbitrary
             // number could be made configurable, if desired.
 
-            if run_missed_event {
+            if run_missed_task {
                 Ok(())
             } else {
                 let now = chrono::Utc::now().with_timezone(wait_until.offset());


### PR DESCRIPTION
If a user's device, for whatever reason, goes to sleep, it may miss the event which it was waiting for. The  behaviour in `tokio-walltime` (#45) is for the future to return immediately upon wake-up, if the `wait_until` argument has been exceeded.

In this case, a user may either want to `run` the task anyway, regardless of how overdue it is, or they may want to `skip` the task altogether.

I have implemented this as an optional flag to the `wait` subcommand: `run-missed-task`. 

I have elected for the default behaviour (i.e. the absence of the flag) to skip the task if the event has been missed by >30 seconds. This is because `heliocron` claims that it will run a user's task at a given time. If that time is then wildly incorrect, then that would be surprising behaviour. Therefore, the user has to explicitly say that they want to run the task "at {chosen event} or any time afterwards in the event my device fell asleep for a few hours and missed it when it originally occurred".

The choice for 30 seconds tolerance is pretty arbitrary but allows for a few seconds of processor scheduling delays etc. There is no reason this couldn't be customisable in a future release.