### PR TITLE
Add 'now' command.

### DIFF
--- a/src/bin/heliocron.rs
+++ b/src/bin/heliocron.rs
@@ -9,6 +9,7 @@ async fn run_heliocron() -> Result<(), errors::HeliocronError> {
 
     match config.action {
         config::Action::Report { json } => subcommands::display_report(solar_calculations, json)?,
+        config::Action::Now { civil } => subcommands::display_now(solar_calculations, civil)?,
         config::Action::Wait {
             event,
             offset,

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,13 @@ pub enum Commands {
         json: bool,
     },
 
+    /// Report whether it is day or night right now
+    Now {
+        /// Report day/night based on civil dawn/dusk rather than sunrise/sunset
+        #[clap(short = 'c', long = "civil")]
+        civil: bool,
+    },
+
     Wait {
         #[clap(
             help = "Choose an event from which to base your delay.", 
@@ -189,6 +196,9 @@ impl TomlConfig {
 
 #[derive(Debug, Clone)]
 pub enum Action {
+    Now {
+        civil: bool,
+    },
     Report {
         json: bool,
     },
@@ -251,6 +261,7 @@ impl Config {
                     run_missed_task,
                 }
             }
+            Commands::Now { civil } => Action::Now { civil },
             Commands::Report { json } => Action::Report { json },
         };
 

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -1,6 +1,6 @@
 use std::result;
 
-use chrono::Duration;
+use chrono::{Duration, Local};
 
 use super::{calc, enums, errors, report, utils};
 
@@ -14,6 +14,33 @@ pub fn display_report(solar_calculations: calc::SolarCalculations, json: bool) -
         report.to_string()
     };
     println!("{}", output);
+    Ok(())
+}
+
+pub fn display_now(sc: calc::SolarCalculations, civil: bool) -> Result<()> {
+    // Get times for sunrise/sunset or dawn/dusk
+    let report = report::SolarReport::new(sc);
+
+    let (begin, end) = match if civil {
+        (report.civil_dawn.datetime, report.civil_dusk.datetime)
+    } else {
+        (report.sunrise.datetime, report.sunset.datetime)
+    } {
+        (Some(begin), Some(end)) => (begin, end),
+        (Some(_), None) => panic!("Missing value for dusk"),
+        (None, Some(_)) => panic!("Missing value for dawn"),
+        (None, None) => panic!("Missing values for dawn and dusk"),
+    };
+
+    // Is the current time between these two?
+    let now = Local::now();
+
+    if begin <= now && now <= end {
+        println!("day");
+    } else {
+        println!("night");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Allow users to query whether it is day or night right now according to either sunrise/sunset or civil dawn/dusk.

Closes #54.