### PR TITLE
Fix aarch64 sleep

### DIFF
--- a/.github/workflows/build_branch_release.yml
+++ b/.github/workflows/build_branch_release.yml
@@ -1,0 +1,60 @@
+name: "Build Branch Releases"
+
+on:
+  workflow_dispatch:
+
+env:
+  RUST_BACKTRACE: full
+
+jobs:
+  build-release:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    env:
+      NATIVE_TARGET: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf, aarch64]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+        if: env.NATIVE_TARGET == 'false'
+
+      - name: Set build binary
+        run: |
+          if ${NATIVE_TARGET} == true; then
+            echo "build_binary=cargo" >> $GITHUB_ENV
+          else
+            echo "build_binary=cross" >> $GITHUB_ENV
+          fi
+
+      - name: Build binary
+        run: ${{ env.build_binary }} build --release --verbose --locked --target ${{ matrix.target }}
+
+      - name: Build archive
+        shell: bash
+        run: |
+          cp target/${{ matrix.target }}/release/heliocron ./heliocron
+          tar -czvf "heliocron-${GITHUB_REF#refs/tags/}-${{ matrix.target }}.tar.gz" heliocron README.md LICENSE-APACHE LICENSE-MIT
+          echo "ASSET=heliocron-${GITHUB_REF#refs/tags/}-${{ matrix.target }}.tar.gz" >> $GITHUB_ENV
+
+      - name: Create release directory for artifact
+        shell: bash
+        run: |
+          mkdir release
+          mv ${{ env.ASSET }} release/
+
+      - name: Save release as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          retention-days: 3
+          name: release
+          path: release

--- a/.github/workflows/build_releases.yml
+++ b/.github/workflows/build_releases.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf]
+        target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf, aarch64]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf]
+        target: [x86_64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf, aarch64]
     steps:
       - uses: actions/checkout@v3
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run tests
         run: ${{ env.test_runner }} test --no-fail-fast --verbose --target ${{ matrix.target }} -- --nocapture
-  
+
   lint:
     name: Check Rust code with rustfmt and clippy
     runs-on: ubuntu-latest

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,11 @@
 use std::result;
 
 use chrono::{DateTime, FixedOffset, Local, TimeZone};
-use tokio_walltime;
+use tokio::time::sleep;
 
 use super::errors::{HeliocronError, RuntimeErrorKind};
 
 type Result<T> = result::Result<T, HeliocronError>;
-
-async fn sleep(time: DateTime<FixedOffset>) -> Result<()> {
-    if cfg!(feature = "integration-test") {
-        println!("Fake sleep until {}.", time);
-    } else {
-        tokio_walltime::sleep_until(time).await?;
-    }
-    Ok(())
-}
 
 pub(crate) async fn wait(wait_until: DateTime<FixedOffset>) -> Result<()> {
     let local_time = Local::now();
@@ -36,7 +27,7 @@ pub(crate) async fn wait(wait_until: DateTime<FixedOffset>) -> Result<()> {
         duration_to_wait.as_secs(),
         wait_until
     );
-    sleep(wait_until).await?;
+    sleep(duration_to_wait).await;
     Ok(())
 }
 


### PR DESCRIPTION
As another user described in #74,  the `wait` function in utils.rs returns immediately on 64-bit Raspbian OS, regardless of the value of the `wait_until` parameter.

Reverting to use of `tokio::time::sleep` fixes the problem, so it appears to be in the `tokio_walltime::sleep` on that platform.

