### PR TITLE
bring tokio-walltime in-house and fix the undefined behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,12 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,23 +207,12 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -273,12 +256,13 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "errno",
+ "libc",
  "predicates",
  "pretty_assertions",
  "serde",
  "serde_json",
  "tokio",
- "tokio-walltime",
  "toml",
 ]
 
@@ -330,9 +314,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "lock_api"
@@ -368,7 +352,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -447,7 +431,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -524,18 +508,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -760,19 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-walltime"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f222a1e05f1772506026ba6a997536441f1de4565ad205462e014079d95536"
-dependencies = [
- "chrono",
- "errno",
- "libc",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,12 +822,43 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -865,10 +867,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -877,13 +897,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,14 @@ integration-test = []
 
 [dependencies]
 chrono = "0.4"
+clap = { version = "3", features = ["derive"] }
 crossterm = "0.24.0"
 dirs = "4"
+errno = "0.3.12"
+libc = "0.2.172"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-clap = { version = "3", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-tokio-walltime =  "0.1.2"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
 toml = "0.5"
 
 [dev-dependencies]
@@ -34,5 +35,5 @@ pretty_assertions = "1"
 
 [profile.release]
 codegen-units = 1
-lto = "fat"
+lto = true
 opt-level = 3

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
+use crate::sleep;
 use chrono::{self, DateTime, FixedOffset};
-use tokio_walltime;
 
 #[derive(Debug)]
 pub enum HeliocronError {
@@ -45,7 +45,7 @@ pub enum RuntimeErrorKind {
     NonOccurringEvent,
     PastEvent(DateTime<FixedOffset>),
     EventMissed(i64),
-    SleepError(tokio_walltime::Error),
+    SleepError(sleep::Error),
 }
 
 impl std::fmt::Display for HeliocronError {
@@ -89,8 +89,8 @@ impl From<chrono::ParseError> for HeliocronError {
     }
 }
 
-impl From<tokio_walltime::Error> for HeliocronError {
-    fn from(err: tokio_walltime::Error) -> Self {
+impl From<sleep::Error> for HeliocronError {
+    fn from(err: sleep::Error) -> Self {
         HeliocronError::Runtime(RuntimeErrorKind::SleepError(err))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod domain;
 pub mod errors;
 pub mod report;
+mod sleep;
 pub mod subcommands;
 pub mod traits;
 pub mod utils;

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use errno::errno;
-use libc;
 use std::{mem::MaybeUninit, ptr};
 use tokio::signal::unix::{signal, SignalKind};
 

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -1,0 +1,100 @@
+use chrono::{DateTime, Utc};
+use errno::errno;
+use libc;
+use std::{mem::MaybeUninit, ptr};
+use tokio::signal::unix::{signal, SignalKind};
+
+#[derive(Debug)]
+pub enum Error {
+    Errno(errno::Errno),
+    Io(std::io::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::Io(err)
+    }
+}
+impl From<errno::Errno> for Error {
+    fn from(err: errno::Errno) -> Self {
+        Error::Errno(err)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Errno(errno) => write!(f, "{errno}"),
+            Error::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+unsafe fn arm_timer(duration: i64) -> Result<libc::timer_t> {
+    // First, initialize our timer
+    let mut timer: libc::timer_t = MaybeUninit::zeroed().assume_init();
+    // this means we are going to create a SIGALRM
+    let mut sev: libc::sigevent = MaybeUninit::zeroed().assume_init();
+    sev.sigev_notify = libc::SIGEV_SIGNAL;
+    sev.sigev_signo = SignalKind::alarm().as_raw_value();
+    if libc::timer_create(libc::CLOCK_REALTIME, &mut sev, &mut timer) != 0 {
+        return Err(Error::from(errno()));
+    }
+
+    // Now, get the time to sleep until
+    let mut its = libc::itimerspec {
+        it_interval: libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        },
+        it_value: MaybeUninit::zeroed().assume_init(),
+    };
+    // by getting the current time
+    if libc::clock_gettime(libc::CLOCK_REALTIME, &mut its.it_value) != 0 {
+        let err = Err(Error::from(errno()));
+        disarm_timer(timer)?;
+        return err;
+    }
+
+    // and changing the duration
+    its.it_value.tv_sec += duration as libc::time_t;
+
+    // Finally, arm the timer
+    if libc::timer_settime(timer, libc::TIMER_ABSTIME, &its, ptr::null_mut()) != 0 {
+        let err = Err(Error::from(errno()));
+        disarm_timer(timer)?;
+        return err;
+    }
+
+    Ok(timer)
+}
+unsafe fn disarm_timer(timer: libc::timer_t) -> Result<()> {
+    if libc::timer_delete(timer) != 0 {
+        return Err(Error::from(errno()));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub async fn sleep_until<Tz: chrono::TimeZone>(time: DateTime<Tz>) -> Result<()> {
+    let time = time.with_timezone(&Utc);
+    // we must schedule our signal handler before the first signal appears
+    let mut alarm = signal(SignalKind::alarm())?;
+    loop {
+        let currtime = Utc::now();
+        let seconds_to_sleep = (time - currtime).num_seconds();
+        if seconds_to_sleep < 0 {
+            break;
+        }
+        // now we set a timer for the specified date
+        let timer = unsafe { arm_timer(seconds_to_sleep)? };
+        // and wait for the signal
+        alarm.recv().await;
+        unsafe { disarm_timer(timer)? }
+    }
+    Ok(())
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use std::result;
 
+use crate::sleep;
 use chrono::{DateTime, FixedOffset, Local, TimeZone};
-use tokio_walltime;
 
 use super::errors::{HeliocronError, RuntimeErrorKind};
 
@@ -11,7 +11,7 @@ async fn sleep(time: DateTime<FixedOffset>) -> Result<()> {
     if cfg!(feature = "integration-test") {
         println!("Fake sleep until {time}.");
     } else {
-        tokio_walltime::sleep_until(time).await?;
+        sleep::sleep_until(time).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
the `sleep` function was getting optimised away in `--release` mode. I think the problem was that `tokio-walltime` was using undefined behaviour by using uninitialised memory. `zero`ing the memory in the first instance appears to have fixed the problem.

fixes #74 